### PR TITLE
feat: 支持序列化嵌套对象，支持自定义序列化函数

### DIFF
--- a/src/ali-sls.ts
+++ b/src/ali-sls.ts
@@ -72,4 +72,8 @@ export interface PinoAliSLSOption {
          */
         time?: string | number
     }
+    /**
+    Optional custom serializer for the 'value' property in contents = [{ key, value }] array
+    */
+    serializer?(value: any): string
 }


### PR DESCRIPTION
你好，我刚好需要一个pino-sls的transport，搜到了现成的代码，谢谢开源！

但是我现在的项目日志里有嵌套的结构，所以我添加了`serializeValue`，用JSON.stringify做了简单的序列化。改完以后又觉得允许用户自定义更灵活一些，所以对`PinoAliSLSOption`添加了可选的自定义序列化函数。

如果哪里还有疏漏，随时告诉我。希望这个改动能被合并，然后尽快更新到npm上